### PR TITLE
Fix share email case sensitivity and theme settings default override.

### DIFF
--- a/prisma/swagger.yaml
+++ b/prisma/swagger.yaml
@@ -2302,6 +2302,8 @@ components:
         theme:
           type: "string"
           example: "auto"
+          nullable: true
+          description: "Null when the user has never saved theme preferences."
         view_mode:
           type: "string"
           example: "cards"

--- a/src/modules/car-access/car-access.service.ts
+++ b/src/modules/car-access/car-access.service.ts
@@ -68,8 +68,9 @@ export class CarAccessService {
       throw new BadRequestException('Cannot assign OWNER role via invite');
     }
 
-    const target = await this.prisma.user.findUnique({ where: { email: dto.email } });
-    if (!target) throw new NotFoundException(`No registered user with email ${dto.email}`);
+    const email = dto.email.trim().toLowerCase();
+    const target = await this.prisma.user.findUnique({ where: { email } });
+    if (!target) throw new NotFoundException(`No registered user with email ${email}`);
     if (target.id === owner.id) throw new BadRequestException('Cannot invite yourself');
 
     const existing = await this.prisma.carUserAccess.findUnique({

--- a/src/modules/user-settings/dto/user-settings.dto.ts
+++ b/src/modules/user-settings/dto/user-settings.dto.ts
@@ -4,8 +4,8 @@ export class UserSettingsDto {
     @ApiProperty({ example: 'en' })
     language: string;
 
-    @ApiProperty({ example: 'auto' })
-    theme: string;
+    @ApiProperty({ example: 'auto', nullable: true, description: 'Null when the user has never saved theme preferences.' })
+    theme: string | null;
 
     @ApiProperty({ example: 'cards' })
     view_mode: string;

--- a/src/modules/user-settings/user-settings.service.ts
+++ b/src/modules/user-settings/user-settings.service.ts
@@ -12,7 +12,7 @@ export class UserSettingsService {
     async getSettings(userId: number): Promise<UserSettingsDto> {
         const settings = await this.prisma.userSettings.findUnique({ where: { user_id: userId } });
         if (!settings) {
-            return DEFAULT_SETTINGS;
+            return { ...DEFAULT_SETTINGS, theme: null };
         }
         return {
             language: settings.language,


### PR DESCRIPTION
Normalize invite emails to lowercase and return null theme when user has no saved preferences.